### PR TITLE
Refactor(Search.jsx): Break out <input> to separate component

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/features/Search/Search.jsx
+++ b/src/features/Search/Search.jsx
@@ -1,68 +1,19 @@
-import { useRef, useEffect, useState } from "react";
+import { useState } from "react";
 
+import { SearchInput } from "./components/Input/SearchInput";
 import { Result } from "./components/Result/Result";
-import { fetchSymbolHandler } from "./api/alpha-vantage/fetch-symbol-handler";
 import * as styles from "./Search.module.css";
 
 export const Search = (props) => {
   const [searchResults, setSearchResults] = useState([]);
-  const [searchQuery, setSearchQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const focusSearch = useRef(null);
-
-  useEffect(() => {
-    focusSearch.current.focus();
-  });
-
-  const loadSymbols = (query) => {
-    return fetchSymbolHandler(query);
-  };
-
-  const sleep = (ms) => {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  };
-
-  useEffect(() => {
-    let currentQuery = true;
-    const controller = new AbortController();
-
-    const loadSearchResults = async () => {
-      if (!searchQuery) {
-        setIsLoading(false);
-        return setSearchResults([]);
-      }
-
-      setIsLoading(true);
-      setSearchResults([]);
-
-      await sleep(500);
-      if (currentQuery) {
-        const results = await loadSymbols(searchQuery, controller);
-        setSearchResults(results);
-        setIsLoading(false);
-      }
-    };
-
-    loadSearchResults();
-
-    return () => {
-      currentQuery = false;
-      controller.abort();
-    };
-  }, [searchQuery]);
 
   return (
     <>
-      <div className={styles["SearchField"]}>
-        <input
-          className={styles["SearchField__Input"]}
-          type="text"
-          placeholder="Enter your search for a stock ticker or company name, currency pair, or crypto/fiat currency pair."
-          value={searchQuery}
-          onChange={(event) => setSearchQuery(event.target.value)}
-          ref={focusSearch}
-        ></input>
-      </div>
+      <SearchInput
+        onSetSearchResults={setSearchResults}
+        onSetIsLoading={setIsLoading}
+      />
       <div className={styles["SearchResultsGrid"]}>
         <div className={styles["SearchResultsHeader"]}>
           <div>Type</div>

--- a/src/features/Search/Search.module.css
+++ b/src/features/Search/Search.module.css
@@ -1,23 +1,3 @@
-.SearchField {
-  align-items: center;
-  background-color: #ffff;
-  display: flex;
-  justify-content: center;
-  margin: 0 0.5rem 0 0.1rem;
-  padding: 0.5rem 0 0.5rem 0;
-  position: sticky;
-  top: 46px;
-  width: 100%;
-  z-index: 10;
-}
-
-.SearchField__Input {
-  margin-bottom: 0.5rem;
-  padding: 0.2rem 0.2rem 0.3rem 0.2rem;
-  width: 100%;
-  z-index: 10;
-}
-
 .SearchResultsGrid {
   align-items: center;
   background-color: #ffff;

--- a/src/features/Search/api/alpha-vantage/fetch-symbol-handler.js
+++ b/src/features/Search/api/alpha-vantage/fetch-symbol-handler.js
@@ -2,10 +2,10 @@ import { fetchStockSymbols } from "./stock-data-handlers";
 import { fetchCurrencySymbols } from "./currency-data-handlers";
 import { fetchCryptoSymbols } from "./crypto-data-handlers";
 
-export const fetchSymbolHandler = async (searchQuery) => {
+export const fetchSymbolHandler = async (searchQuery, signal) => {
   const searchResults = [];
 
-  const stockSearchResults = await fetchStockSymbols(searchQuery);
+  const stockSearchResults = await fetchStockSymbols(searchQuery, signal);
   const currencySearchResults = fetchCurrencySymbols(searchQuery);
   const cryptoSearchResults = fetchCryptoSymbols(searchQuery);
 
@@ -15,8 +15,10 @@ export const fetchSymbolHandler = async (searchQuery) => {
     cryptoSearchResults
   );
 
+  console.log();
+
   const mergedSearchResults = searchResults
-    .filter((obj) => obj.length > 0)
+    .filter((obj) => obj && obj.length > 0)
     .flat()
     .filter((obj, index) => index < 999);
 

--- a/src/features/Search/api/alpha-vantage/stock-data-handlers.js
+++ b/src/features/Search/api/alpha-vantage/stock-data-handlers.js
@@ -1,9 +1,10 @@
 import { apiKey } from "./alpha-vantage-key";
 
-export const fetchStockSymbols = async (searchQuery) => {
+export const fetchStockSymbols = async (searchQuery, signal) => {
   try {
     const response = await fetch(
-      `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${searchQuery}&apikey=${apiKey}`
+      `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${searchQuery}&apikey=${apiKey}`,
+      { signal }
     );
     if (!response.ok) {
       throw new Error("Something went wrong!");

--- a/src/features/Search/components/Input/SearchInput.jsx
+++ b/src/features/Search/components/Input/SearchInput.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState, useRef } from "react";
+
+import { fetchSymbolHandler } from "../../api/alpha-vantage/fetch-symbol-handler";
+import styles from "./SearchInput.module.css";
+
+export const SearchInput = (props) => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const focusInput = useRef(null);
+
+  useEffect(() => {
+    focusInput.current.focus();
+  });
+
+  const loadSearchResults = useRef((query, signal) => {
+    if (!query) {
+      props.onSetIsLoading(false);
+      props.onSetSearchResults([]);
+      return;
+    } else {
+      props.onSetIsLoading(true);
+      props.onSetSearchResults([]);
+
+      const results = fetchSymbolHandler(query, signal);
+      props.onSetSearchResults(results);
+      props.onSetIsLoading(false);
+    }
+  }).current;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const timeOutId = setTimeout(
+      () => loadSearchResults(searchQuery, signal),
+      500
+    );
+
+    return () => {
+      clearTimeout(timeOutId);
+      controller.abort();
+    };
+  }, [searchQuery, loadSearchResults]);
+
+  return (
+    <form className={styles["SearchField"]}>
+      <input
+        className={styles["SearchField__Input"]}
+        type="text"
+        placeholder="Enter your search for a stock ticker or company name, currency pair, or crypto/currency pair."
+        onChange={(event) => setSearchQuery(event.target.value)}
+        ref={focusInput}
+      ></input>
+    </form>
+  );
+};

--- a/src/features/Search/components/Input/SearchInput.module.css
+++ b/src/features/Search/components/Input/SearchInput.module.css
@@ -1,0 +1,19 @@
+.SearchField {
+  align-items: center;
+  background-color: #ffff;
+  display: flex;
+  justify-content: center;
+  margin: 0 0.5rem 0 0.1rem;
+  padding: 0.5rem 0 0.5rem 0;
+  position: sticky;
+  top: 46px;
+  width: 100%;
+  z-index: 10;
+}
+
+.SearchField__Input {
+  margin-bottom: 0.5rem;
+  padding: 0.2rem 0.2rem 0.3rem 0.2rem;
+  width: 100%;
+  z-index: 10;
+}


### PR DESCRIPTION
- Broke out the input field in Search.jsx to its own component at src/features/Search/components/Input/SearchInput.jsx. 
  The component handles passing the search query to fetchSymbolHandler, and updating the state of searchResults and 
  isLoading, which are props passed down from Search.jsx.

- Changed the div tag that wrapped the input element to a form tag to be more semantically correct.

- Made the AbortController work properly by passing the AbortController.signal property down to the fetchStockSymbols 
  function. Calling controller.abort() in the useEffect cleanup preventsunnecessary api requests being made if the user quickly 
  changes their search query.

- In fetch-symbol-handler: Added another condition in the filter method on mergedSearchResults to see if the current element 
  is truthy, because there was an error being thrown of the type "Can't read length of undefined."