### PR TITLE
Refactor(CSS class names): Switch to camelCase and dot notation

### DIFF
--- a/src/features/Chart/Chart.jsx
+++ b/src/features/Chart/Chart.jsx
@@ -26,11 +26,8 @@ export const Chart = (props) => {
   };
 
   return (
-    <div className={styles["Chart"]}>
-      <button
-        className={styles["CloseButton"]}
-        onClick={removeHandler}
-      ></button>
+    <div className={styles.chart}>
+      <button className={styles.closeButton} onClick={removeHandler}></button>
       <HighchartsReact
         highcharts={Highcharts}
         constructorType={"stockChart"}

--- a/src/features/Chart/Chart.module.css
+++ b/src/features/Chart/Chart.module.css
@@ -1,4 +1,4 @@
-.Chart {
+.chart {
   align-items: center;
   background: inherit;
   display: flex;
@@ -9,7 +9,7 @@
   width: 730px;
 }
 
-.CloseButton {
+.closeButton {
   background-color: #fff;
   border: 1px solid #0a8e26;
   border-radius: 50%;
@@ -23,7 +23,7 @@
   z-index: 10;
 }
 
-.CloseButton::before {
+.closeButton::before {
   background-color: #222;
   bottom: 4px;
   content: " ";
@@ -36,7 +36,7 @@
   width: 2px;
 }
 
-.CloseButton::after {
+.closeButton::after {
   background-color: #222;
   content: " ";
   display: block;
@@ -49,7 +49,7 @@
   transition: all 0.5s ease-in-out;
 }
 
-.CloseButton:hover:before,
-.CloseButton:hover:after {
+.closeButton:hover:before,
+.closeButton:hover:after {
   background-color: #0a8e26;
 }

--- a/src/features/Search/Search.jsx
+++ b/src/features/Search/Search.jsx
@@ -17,16 +17,16 @@ export const Search = (props) => {
         onSetSearchResults={setSearchResults}
         onSetIsLoading={setIsLoading}
       />
-      <div className={styles["SearchResultsGrid"]}>
-        <div className={styles["SearchResultsHeader"]}>
+      <div className={styles.searchResultGrid}>
+        <div className={styles.searchResultHeader}>
           <div>Type</div>
         </div>
-        <div className={styles["SearchResultsHeader"]}>
+        <div className={styles.searchResultHeader}>
           <div>Symbol</div>
         </div>
         <div
-          className={`${styles["SearchResultsHeader"]} 
-          ${styles["SearchResultsHeader__Name"]}`}
+          className={`${styles.searchResultHeader} 
+          ${styles.searchResultHeader__name}`}
         >
           <div>Name</div>
         </div>

--- a/src/features/Search/Search.module.css
+++ b/src/features/Search/Search.module.css
@@ -1,4 +1,4 @@
-.SearchResultsGrid {
+.searchResultGrid {
   align-items: center;
   background-color: #ffff;
   display: grid;
@@ -8,7 +8,7 @@
   z-index: 10;
 }
 
-.SearchResultsHeader {
+.searchResultHeader {
   background-color: #ffff;
   border-bottom: 0.1rem solid #eee;
   color: #0a8e27de;
@@ -18,6 +18,6 @@
   z-index: 10;
 }
 
-.SearchResultsHeader__Name {
+.searchResultHeader__name {
   grid-column-start: span 2;
 }

--- a/src/features/Search/api/alpha-vantage/fetch-symbol-handler.js
+++ b/src/features/Search/api/alpha-vantage/fetch-symbol-handler.js
@@ -15,8 +15,6 @@ export const fetchSymbolHandler = async (searchQuery, signal) => {
     cryptoSearchResults
   );
 
-  console.log();
-
   const mergedSearchResults = searchResults
     .filter((obj) => obj && obj.length > 0)
     .flat()

--- a/src/features/Search/components/Input/SearchInput.jsx
+++ b/src/features/Search/components/Input/SearchInput.jsx
@@ -21,7 +21,6 @@ export const SearchInput = (props) => {
       props.onSetSearchResults([]);
 
       const results = await fetchSymbolHandler(query, signal);
-      console.log(results);
       props.onSetSearchResults(results);
       props.onSetIsLoading(false);
     }
@@ -30,7 +29,6 @@ export const SearchInput = (props) => {
   useEffect(() => {
     const controller = new AbortController();
     const signal = controller.signal;
-    console.log(searchQuery);
     const timeOutId = setTimeout(
       () => loadSearchResults(searchQuery, signal),
       500
@@ -43,9 +41,9 @@ export const SearchInput = (props) => {
   }, [searchQuery, loadSearchResults]);
 
   return (
-    <form className={styles["SearchField"]}>
+    <form className={styles.searchField}>
       <input
-        className={styles["SearchField__Input"]}
+        className={styles.searchField__input}
         type="text"
         placeholder="Enter your search for a stock ticker or company name, currency pair, or crypto/currency pair."
         onChange={(event) => setSearchQuery(event.target.value)}

--- a/src/features/Search/components/Input/SearchInput.module.css
+++ b/src/features/Search/components/Input/SearchInput.module.css
@@ -1,4 +1,4 @@
-.SearchField {
+.searchField {
   align-items: center;
   background-color: #ffff;
   display: flex;
@@ -11,7 +11,7 @@
   z-index: 10;
 }
 
-.SearchField__Input {
+.searchField__input {
   margin-bottom: 0.5rem;
   padding: 0.2rem 0.2rem 0.3rem 0.2rem;
   width: 100%;

--- a/src/features/Search/components/Result/SearchResult.jsx
+++ b/src/features/Search/components/Result/SearchResult.jsx
@@ -2,19 +2,19 @@ import styles from "./SearchResult.module.css";
 
 export const SearchResult = (props) => {
   return (
-    <div className={styles["SearchResultWrapper"]}>
-      <div className={styles["SearchResult"]}>
+    <div className={styles.searchResultWrapper}>
+      <div className={styles.searchResult}>
         <div>{props.type}</div>
       </div>
-      <div className={styles["SearchResult"]}>
+      <div className={styles.searchResult}>
         <div>{props.symbol}</div>
       </div>
-      <div className={styles["SearchResult"]}>
+      <div className={styles.searchResult}>
         <div>{props.name}</div>
       </div>
-      <div className={styles["SearchResultButton"]}>
+      <div className={styles.searchResultButton}>
         <button
-          className={styles["SearchResultButton__AddChart"]}
+          className={styles.searchResultButton__addChart}
           onClick={props.onClick}
         ></button>
       </div>

--- a/src/features/Search/components/Result/SearchResult.module.css
+++ b/src/features/Search/components/Result/SearchResult.module.css
@@ -1,20 +1,20 @@
-.SearchResultWrapper {
+.searchResultWrapper {
   display: contents;
 }
-.SearchResult {
+.searchResult {
   border-bottom: 0.1rem solid #eee;
   padding: 1rem;
   z-index: 0;
 }
 
-.SearchResultButton {
+.searchResultButton {
   border-bottom: 0.1rem solid #eee;
   display: flex;
   justify-content: center;
   padding: 1rem;
 }
 
-.SearchResultButton__AddChart {
+.searchResultButton__addChart {
   background-color: #ffff;
   border: none;
   box-sizing: border-box;
@@ -26,8 +26,8 @@
   z-index: 0;
 }
 
-.SearchResultButton__AddChart::after,
-.SearchResultButton__AddChart::before {
+.searchResultButton__addChart::after,
+.searchResultButton__addChart::before {
   background: #0a8e26;
   box-sizing: border-box;
   content: "";
@@ -40,7 +40,7 @@
   z-index: 0;
 }
 
-.SearchResultButton__AddChart::after {
+.searchResultButton__addChart::after {
   height: 20px;
   left: 9px;
   top: 1px;
@@ -48,6 +48,6 @@
   z-index: 0;
 }
 
-.SearchResultButton__AddChart:active {
+.searchResultButton__addChart:active {
   transform: translateY(2px);
 }

--- a/src/features/ui/Dashboard/Dashboard.jsx
+++ b/src/features/ui/Dashboard/Dashboard.jsx
@@ -3,7 +3,7 @@ import * as styles from "./Dashboard.module.css";
 
 export const Dashboard = (props) => {
   return (
-    <div className={styles["DashboardGrid"]}>
+    <div className={styles.dashboardGrid}>
       {props.selectedCharts.map((item, index) => (
         <Chart
           key={index}

--- a/src/features/ui/Dashboard/Dashboard.module.css
+++ b/src/features/ui/Dashboard/Dashboard.module.css
@@ -1,4 +1,4 @@
-.DashboardGrid {
+.dashboardGrid {
   display: grid;
   grid-gap: 1rem;
   grid-template-columns: 1fr 1fr 1fr;

--- a/src/features/ui/Header/Header.jsx
+++ b/src/features/ui/Header/Header.jsx
@@ -5,10 +5,10 @@ export const Header = (props) => {
     props.toggleModal(true);
   };
   return (
-    <header className={styles["Header"]}>
-      <h1 className={styles["Header__Title"]}>FinDash</h1>
+    <header className={styles.header}>
+      <h1 className={styles.header__title}>FinDash</h1>
       <button
-        className={styles["Header__OpenModalButton"]}
+        className={styles.header__openModalButton}
         onClick={toggleModalHandler}
       >
         Add chart

--- a/src/features/ui/Header/Header.module.css
+++ b/src/features/ui/Header/Header.module.css
@@ -1,4 +1,4 @@
-.Header {
+.header {
   background-color: #fdffff;
   border-bottom: 1px solid #0a8e26;
   display: grid;
@@ -10,7 +10,12 @@
   width: 100vw;
 }
 
-.Header__OpenModalButton {
+.header__title {
+  margin-left: 50%;
+  padding-top: 1rem;
+}
+
+.header__openModalButton {
   background-color: #ffff;
   border: 0.15rem solid #0a8e26;
   cursor: pointer;
@@ -19,9 +24,4 @@
   margin-top: 1rem;
   text-align: center;
   text-decoration: none;
-}
-
-.Header__Title {
-  margin-left: 50%;
-  padding-top: 1rem;
 }

--- a/src/features/ui/Modal/Modal.jsx
+++ b/src/features/ui/Modal/Modal.jsx
@@ -12,21 +12,21 @@ const ModalOverlay = (props) => {
 
   return (
     <div
-      className={classNames(styles["Modal"], {
-        [styles["Modal--Show"]]: props.show,
+      className={classNames(styles.modal, {
+        [styles.modal_show]: props.show,
       })}
       onClick={closeModal}
     >
       <div
-        className={classNames(styles["ModalContent"], {
-          [styles["ModalContent--Show"]]: props.show,
+        className={classNames(styles.modalContent, {
+          [styles.modalContent_show]: props.show,
         })}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className={styles["ModalHeader"]}>
-          <h2 className={styles["ModalTitle"]}>Add chart</h2>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>Add chart</h2>
           <button
-            className={styles["CloseModalButton"]}
+            className={styles.closeModalButton}
             onClick={closeModal}
           ></button>
         </div>

--- a/src/features/ui/Modal/Modal.module.css
+++ b/src/features/ui/Modal/Modal.module.css
@@ -1,4 +1,4 @@
-.Modal {
+.modal {
   align-items: center;
   background-color: rgba(0, 0, 0, 0.5);
   bottom: 0;
@@ -16,13 +16,13 @@
   z-index: 100;
 }
 
-.Modal--Show {
+.modal_show {
   opacity: 1;
   pointer-events: visible;
   transform: translateY(0);
 }
 
-.ModalContent {
+.modalContent {
   background-color: #fff;
   border: 0.15rem solid #0a8e26;
   height: 50rem;
@@ -35,11 +35,11 @@
   width: 50rem;
 }
 
-.ModalContent--Show {
+.modalContent_show {
   transform: translateY(0);
 }
 
-.ModalHeader {
+.modalHeader {
   align-content: center;
   background-color: white;
   display: flex;
@@ -50,14 +50,14 @@
   z-index: 10;
 }
 
-.ModalTitle {
+.modalTitle {
   color: #131722;
   font-size: 20px;
   margin: 0;
   z-index: 10;
 }
 
-.CloseModalButton {
+.closeModalButton {
   background-color: #fff;
   border: none;
   color: #eeee;
@@ -69,7 +69,7 @@
   z-index: 10;
 }
 
-.CloseModalButton::before {
+.closeModalButton::before {
   content: " ";
   background-color: #bbbb;
   display: block;
@@ -82,7 +82,7 @@
   width: 2px;
   z-index: 10;
 }
-.CloseModalButton::after {
+.closeModalButton::after {
   background-color: #bbbb;
   content: " ";
   display: block;
@@ -96,7 +96,7 @@
   z-index: 10;
 }
 
-.CloseModalButton:hover:before,
-.CloseModalButton:hover:after {
+.closeModalButton:hover:before,
+.closeModalButton:hover:after {
   background-color: #0a8e26;
 }


### PR DESCRIPTION
- Switched naming convention for CSS classes from PascalCase to camelCase and using dot notation when accessing CSS modules. This makes the code a bit easier on the eyes. Because of the switch to dot notation, it's not possible to use "--" anymore for modifier classes. Instead, I'll use "_" (single underscore).

- Extra: Removed console logs in fetch-symbol-handler.js and SearchInput.jsx that were accidentaly left over from previous branches.