### PR TITLE
bug(app crash): App crashes on chart removal

### DIFF
--- a/src/features/Chart/Chart.jsx
+++ b/src/features/Chart/Chart.jsx
@@ -1,4 +1,5 @@
 import Highcharts from "highcharts/highstock";
+import NoDataToDisplay from "highcharts/modules/no-data-to-display";
 import HighchartsReact from "highcharts-react-official";
 
 import { highchartsConfig } from "./highcharts/highcharts-config";
@@ -8,6 +9,8 @@ export const Chart = (props) => {
   const removeHandler = () => {
     props.onRemoveChart(props.id);
   };
+
+  NoDataToDisplay(Highcharts);
 
   const options = {
     title: {

--- a/src/features/Chart/highcharts/highcharts-config.js
+++ b/src/features/Chart/highcharts/highcharts-config.js
@@ -8,6 +8,9 @@ export const highchartsConfig = {
   credits: {
     enabled: false,
   },
+  lang: {
+    noData: "No data to display for this search. Please try again.",
+  },
   navigator: {
     series: {
       color: "#010101",

--- a/src/features/Search/api/alpha-vantage/crypto-data-handlers.js
+++ b/src/features/Search/api/alpha-vantage/crypto-data-handlers.js
@@ -28,19 +28,22 @@ export const fetchCryptoData = async (currencyPair) => {
 
     const timeseriesData = data["Time Series (Digital Currency Daily)"];
 
-    const formattedData = Object.keys(timeseriesData)
-      .sort()
-      .map((key) => {
-        const formatDate = key.split("-");
-        return [
-          Date.UTC(formatDate[0], formatDate[1] - 1, formatDate[2]),
-          +timeseriesData[key][`1a. open (${toCurrency})`],
-          +timeseriesData[key][`2a. high (${toCurrency})`],
-          +timeseriesData[key][`3a. low (${toCurrency})`],
-          +timeseriesData[key][`4a. close (${toCurrency})`],
-        ];
-      });
-    return formattedData;
+    if (!timeseriesData) {
+      return [];
+    } else {
+      return Object.keys(timeseriesData)
+        .sort()
+        .map((key) => {
+          const formatDate = key.split("-");
+          return [
+            Date.UTC(formatDate[0], formatDate[1] - 1, formatDate[2]),
+            +timeseriesData[key][`1a. open (${toCurrency})`],
+            +timeseriesData[key][`2a. high (${toCurrency})`],
+            +timeseriesData[key][`3a. low (${toCurrency})`],
+            +timeseriesData[key][`4a. close (${toCurrency})`],
+          ];
+        });
+    }
   } catch (error) {
     console.log(error.message);
   }

--- a/src/features/Search/api/alpha-vantage/currency-data-handlers.js
+++ b/src/features/Search/api/alpha-vantage/currency-data-handlers.js
@@ -28,18 +28,24 @@ export const fetchCurrencyData = async (currencyPair) => {
 
     const timeseriesData = data["Time Series FX (Daily)"];
 
-    return Object.keys(timeseriesData)
-      .sort()
-      .map((key) => {
-        const formatDate = key.split("-");
-        return [
-          Date.UTC(formatDate[0], formatDate[1] - 1, formatDate[2]),
-          +timeseriesData[key]["1. open"],
-          +timeseriesData[key]["2. high"],
-          +timeseriesData[key]["3. low"],
-          +timeseriesData[key]["4. close"],
-        ];
-      });
+    console.log("fetchCurrencyData fired. timeseriesData: ", timeseriesData);
+
+    if (!timeseriesData) {
+      return [];
+    } else {
+      return Object.keys(timeseriesData)
+        .sort()
+        .map((key) => {
+          const formatDate = key.split("-");
+          return [
+            Date.UTC(formatDate[0], formatDate[1] - 1, formatDate[2]),
+            +timeseriesData[key]["1. open"],
+            +timeseriesData[key]["2. high"],
+            +timeseriesData[key]["3. low"],
+            +timeseriesData[key]["4. close"],
+          ];
+        });
+    }
   } catch (error) {
     console.log(error.message);
   }

--- a/src/features/Search/api/alpha-vantage/stock-data-handlers.js
+++ b/src/features/Search/api/alpha-vantage/stock-data-handlers.js
@@ -40,19 +40,22 @@ export const fetchStockData = async (stockSymbol) => {
 
     const timeseriesData = data["Time Series (Daily)"];
 
-    const formattedData = Object.keys(timeseriesData)
-      .sort()
-      .map((key) => {
-        const formatDate = key.split("-");
-        return [
-          Date.UTC(formatDate[0], formatDate[1] - 1, formatDate[2]),
-          +timeseriesData[key]["1. open"],
-          +timeseriesData[key]["2. high"],
-          +timeseriesData[key]["3. low"],
-          +timeseriesData[key]["4. close"],
-        ];
-      });
-    return formattedData;
+    if (!timeseriesData) {
+      return [];
+    } else {
+      return Object.keys(timeseriesData)
+        .sort()
+        .map((key) => {
+          const formatDate = key.split("-");
+          return [
+            Date.UTC(formatDate[0], formatDate[1] - 1, formatDate[2]),
+            +timeseriesData[key]["1. open"],
+            +timeseriesData[key]["2. high"],
+            +timeseriesData[key]["3. low"],
+            +timeseriesData[key]["4. close"],
+          ];
+        });
+    }
   } catch (error) {
     console.log(error.message);
   }


### PR DESCRIPTION
- Fixed a bug that caused the app to crash when a chart with data was removed from the dashboard, while the dashboard contained at least one chart with no data (data == undefined) at any index other than 0. Solved by returning an empty array from the fetchCrypto/Stock/CurrencyData functions instead of undefined.

- Imported the NoDataToDisplay module from higcharts to Chart.jsx and added a noData property to highchartsConfig.js to display a custom error message when there is no data to display in the chart.