### PR TITLE
fix(crash on crypto search): App crashed when crypto name contained n…

### DIFF
--- a/src/features/Search/api/alpha-vantage/get-crypto-data.js
+++ b/src/features/Search/api/alpha-vantage/get-crypto-data.js
@@ -1,11 +1,10 @@
 import { apiKey } from "./alpha-vantage-key";
 
 export const getCryptoData = async (currencyPair) => {
-  const regexMatch = currencyPair.match(
-    /^(?<fromCurrency>[a-z]{3,9})\/(?<toCurrency>[a-z]{3})$/i
-  );
-  const fromCurrency = regexMatch.groups.fromCurrency;
-  const toCurrency = regexMatch.groups.toCurrency;
+  const splitCurrencyPair = currencyPair.split("/");
+
+  const fromCurrency = splitCurrencyPair[0];
+  const toCurrency = splitCurrencyPair[1];
 
   try {
     const response = await fetch(

--- a/src/features/Search/api/alpha-vantage/get-currency-data.js
+++ b/src/features/Search/api/alpha-vantage/get-currency-data.js
@@ -1,11 +1,10 @@
 import { apiKey } from "./alpha-vantage-key";
 
 export const getCurrencyData = async (currencyPair) => {
-  const regexMatch = currencyPair.match(
-    /^(?<fromCurrency>[a-z]{3})\/(?<toCurrency>[a-z]{3})$/i
-  );
-  const fromCurrency = regexMatch.groups.fromCurrency;
-  const toCurrency = regexMatch.groups.toCurrency;
+  const splitCurrencyPair = currencyPair.split("/");
+
+  const fromCurrency = splitCurrencyPair[0];
+  const toCurrency = splitCurrencyPair[1];
 
   try {
     const response = await fetch(


### PR DESCRIPTION
…umbers

The app crashed when clicking the add chart button on the search result of a crypto that has at least one number in the name. 
The reason was that the regex match in the getCryptoData function didn't look for numbers.
Solved by simplyfing the function to not use regex match. Instead, currencyPair.split("/") is called and assigned to the splitCurrency constant. Then, the fromCurrency constant is set to splitCurrency[0], and toCurrency to splitCurrency[1].