### PR TITLE
chore(Add deletion of alpha-vantage-key.js to commit)

### DIFF
--- a/src/features/Search/api/alpha-vantage/alpha-vantage-key.js
+++ b/src/features/Search/api/alpha-vantage/alpha-vantage-key.js
@@ -1,1 +1,0 @@
-export const apiKey = "PBKENT6HA5JNEIDY";


### PR DESCRIPTION
Last commit didn't include the change to delete the alpha-vantage-key.js file, because I thought that would stop the file itself and the API key from showing up in the change logs. It turns out that is not the case, and the file wasn't deleted when the chore-move-api-key-to-netlify branch was merged with the master branch.
Therefore, I'm pushing this change after all, even though it won't remove the API key from the repo. But at least it will make the local and online repos match up.

I haven't been able to make the BFG Repo-cleaner work, and I'm letting the issue of the exposed API key go for now. It's after all only a free API key, and I can get a new one easily.
I might take up the task of cleaning the repo again in the future, but for now it's not a priority.