### PR TITLE
refactor(minor improvements)

### DIFF
--- a/.netlify/functions/api.js
+++ b/.netlify/functions/api.js
@@ -1,8 +1,0 @@
-exports.handler = async (event, context) => {
-  return {
-    statusCode: 200,
-    body: JSON.stringify({
-      api: process.env.API_KEY,
-    }),
-  };
-};

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/src/features/Search/api/alpha-vantage/alpha-vantage-key.js
+++ b/src/features/Search/api/alpha-vantage/alpha-vantage-key.js
@@ -1,0 +1,1 @@
+export const apiKey = "PBKENT6HA5JNEIDY";

--- a/src/features/Search/api/alpha-vantage/get-all-search-results.js
+++ b/src/features/Search/api/alpha-vantage/get-all-search-results.js
@@ -3,22 +3,15 @@ import { getCurrencySearchResults } from "./get-currency-search-results";
 import { getCryptoSearchResults } from "./get-crypto-search-results";
 
 export const getAllSearchResults = async (searchQuery, signal) => {
-  const searchResults = [];
-
   const stockSearchResults = await getStockSearchResults(searchQuery, signal);
   const currencySearchResults = getCurrencySearchResults(searchQuery);
   const cryptoSearchResults = getCryptoSearchResults(searchQuery);
 
-  searchResults.push(
+  const searchResults = [
     stockSearchResults,
     currencySearchResults,
-    cryptoSearchResults
-  );
+    cryptoSearchResults,
+  ];
 
-  const mergedSearchResults = searchResults
-    .filter((obj) => obj && obj.length > 0)
-    .flat()
-    .filter((obj, index) => index < 999);
-
-  return mergedSearchResults;
+  return searchResults.flat().filter((result, index) => result && index < 999);
 };

--- a/src/features/Search/api/alpha-vantage/get-crypto-data.js
+++ b/src/features/Search/api/alpha-vantage/get-crypto-data.js
@@ -1,16 +1,10 @@
+import { apiKey } from "./alpha-vantage-key.js";
+
 export const getCryptoData = async (currencyPair) => {
   const splitCurrencyPair = currencyPair.split("/");
 
   const fromCurrency = splitCurrencyPair[0];
   const toCurrency = splitCurrencyPair[1];
-
-  let apiKey;
-
-  fetch(".netlify/functions/api")
-    .then((response) => response.json())
-    .then((json) => {
-      apiKey = json.api;
-    });
 
   try {
     const response = await fetch(

--- a/src/features/Search/api/alpha-vantage/get-currency-data.js
+++ b/src/features/Search/api/alpha-vantage/get-currency-data.js
@@ -1,16 +1,10 @@
+import { apiKey } from "./alpha-vantage-key.js";
+
 export const getCurrencyData = async (currencyPair) => {
   const splitCurrencyPair = currencyPair.split("/");
 
   const fromCurrency = splitCurrencyPair[0];
   const toCurrency = splitCurrencyPair[1];
-
-  let apiKey;
-
-  fetch(".netlify/functions/api")
-    .then((response) => response.json())
-    .then((json) => {
-      apiKey = json.api;
-    });
 
   try {
     const response = await fetch(

--- a/src/features/Search/api/alpha-vantage/get-data-based-on-result-type.js
+++ b/src/features/Search/api/alpha-vantage/get-data-based-on-result-type.js
@@ -1,15 +1,15 @@
 import { getCryptoData } from "./get-crypto-data";
 import { getCurrencyData } from "./get-currency-data";
 import { getStockData } from "./get-stock-data";
-import * as searchType from "../../constants/result-types";
+import * as resultType from "../../constants/result-types";
 
 export const getDataBasedOnResultType = (type, symbol) => {
   switch (type) {
-    case searchType.EQUITY:
+    case resultType.EQUITY:
       return getStockData(symbol);
-    case searchType.CURRENCY:
+    case resultType.CURRENCY:
       return getCurrencyData(symbol);
-    case searchType.CRYPTOCURRENCY:
+    case resultType.CRYPTOCURRENCY:
       return getCryptoData(symbol);
     default:
       throw new Error("Something went wrong!");

--- a/src/features/Search/api/alpha-vantage/get-stock-data.js
+++ b/src/features/Search/api/alpha-vantage/get-stock-data.js
@@ -1,12 +1,6 @@
+import { apiKey } from "./alpha-vantage-key.js";
+
 export const getStockData = async (stockSymbol) => {
-  let apiKey;
-
-  fetch(".netlify/functions/api")
-    .then((response) => response.json())
-    .then((json) => {
-      apiKey = json.api;
-    });
-
   try {
     const response = await fetch(
       `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${stockSymbol}&outputsize=full&apikey=${apiKey}`

--- a/src/features/Search/api/alpha-vantage/get-stock-search-results.js
+++ b/src/features/Search/api/alpha-vantage/get-stock-search-results.js
@@ -1,14 +1,7 @@
-import * as searchTypes from "../../constants/result-types";
+import { apiKey } from "./alpha-vantage-key.js";
+import * as resultType from "../../constants/result-types";
 
 export const getStockSearchResults = async (searchQuery, signal) => {
-  let apiKey;
-
-  fetch(".netlify/functions/api")
-    .then((response) => response.json())
-    .then((json) => {
-      apiKey = json.api;
-    });
-
   try {
     const response = await fetch(
       `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${searchQuery}&apikey=${apiKey}`,
@@ -25,7 +18,7 @@ export const getStockSearchResults = async (searchQuery, signal) => {
         return {
           symbol: stock["1. symbol"],
           name: stock["2. name"],
-          type: searchTypes.EQUITY,
+          type: resultType.EQUITY,
         };
       });
 


### PR DESCRIPTION
Refactored various files to reduce the amount of code, and make it more readable:

  - The last few branches and commits were dedicated to hiding the Alpha Vantage API key, so that it wouldn't be exposed on GitHub. I did this by moving the key to a serverless function at Netlify. I've now realized it was unnecessary and not worth the work. Here's why:
Firstly, the API key wasn't actually hidden just because I moved it to a serverless function at Netlify. It could still very easily by seen by opening the developer console and going to the Network tab. Secondly, it's a free API key. If someone would steal it, it wouldn't have much impact. But crucially, no one would even need to steal it. I learned during this whole process that you don't actually need to provide an API key when making a fetch request to Alpha Vantage's API, even if they say you do. So spending a lot of time trying to hide the key is just not worth it. Not in my situation.
Because of this, I'm returning to the old way handling the API call. I re-created the alpha-vantage-key.js file and import it where it's needed. Even if it turns out it isn't needed, I still do it for propriety's sake.

  - In the files where result-types.js is imported: Changed the import name from "searchType" to "resultType" to be in line with the name of the file.

  - Simplified the getAllSearchResults function. Instead of creating an empty "searchResults" array that has the results of the get-functions pushed to it, I directly create a "searchResults" array that is populated with the results of these functions.
    The array that is returned from getAllSearchResults is no longer stored first in a constant. New is also that the filter method isn't called twice on the same array.