### PR TITLE
fix(netlify deploy failed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8445,7 +8445,8 @@
       "devOptional": true,
       "os": [
         "darwin",
-        "win32"
+        "win32",
+        "linux"
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"


### PR DESCRIPTION
After adding TypeScript to the app and attempting to deploy, the deploy fails with this error log:

"8:02:37 AM: npm ERR! code EBADPLATFORM
8:02:37 AM: npm ERR! notsup Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin,win32"} (current: {"os":"linux","arch":"x64"})
8:02:37 AM: npm ERR! notsup Valid OS:    darwin,win32
8:02:37 AM: npm ERR! notsup Valid Arch:  undefined
8:02:37 AM: Creating deploy upload records
8:02:37 AM: npm ERR! notsup Actual OS:   linux
8:02:37 AM: npm ERR! notsup Actual Arch: x64
8:02:37 AM: npm ERR! A complete log of this run can be found in:
8:02:37 AM: npm ERR!     /opt/buildhome/.npm/_logs/2022-03-16T07_02_36_426Z-debug-0.log
8:02:37 AM: Error during NPM install
8:02:40 AM: Failed during stage 'building site': Build script returned non-zero exit code: 1 (https://ntl.fyi/exit-code-1)
8:02:37 AM: Build was terminated: Build script returned non-zero exit code: 1
8:02:40 AM: Failing build: Failed to build site"

The part of special note here is the one that says "Unsupported platform for "fsevents@2.3.2: wanted {"os":"darwin,win32"} (current: {"os":"linux","arch":"x64"})".

To fix this, I've added linux as a supported os in the package-lock.json file.